### PR TITLE
feat: add colophon page

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,26 +86,55 @@ One of my favorite books is *The Hitchhiker's Guide to the Galaxy*, so I made th
 
 ### Developer Stats
 
-<!-- Option 1: Self-hosted github-readme-stats (paused upstream — deploy your own fork to re-enable)
+**A) github-readme-stats — Stats Overview** *(currently paused upstream)*
 <a href="https://github.com/lacymorrow/">
   <img height=200 align="center" src="https://github-readme-stats.vercel.app/api?username=lacymorrow&show_icons=true&theme=transparent" />
 </a>
+
+**B) github-readme-stats — Top Languages** *(currently paused upstream)*
 <a href="https://github.com/lacymorrow/">
   <img height=200 align="center" src="https://github-readme-stats.vercel.app/api/top-langs/?username=lacymorrow&layout=compact&langs_count=8&card_width=320&theme=transparent&hide=PHP" />
 </a>
 
----
+**C) github-profile-trophy** *(currently paused upstream)*
 
-![Anurag's GitHub stats](https://github-profile-trophy.vercel.app/?username=lacymorrow&margin-w=12&rank=-C,-?&theme=transparent)
--->
+![GitHub Trophies](https://github-profile-trophy.vercel.app/?username=lacymorrow&margin-w=12&rank=-C,-?&theme=transparent)
 
-<!-- Option 2: Streak stats + profile summary cards -->
+**D) Streak Stats (demolab)**
 <a href="https://github.com/lacymorrow/">
   <img height=200 align="center" src="https://streak-stats.demolab.com/?user=lacymorrow&theme=transparent" alt="GitHub Streak" />
 </a>
+
+**E) Streak Stats (herokuapp)**
 <a href="https://github.com/lacymorrow/">
-  <img height=200 align="center" src="https://raw.githubusercontent.com/lacymorrow/lacymorrow/profile-summary-cards/profile-summary-card-output/default/1-repos-per-language.svg" alt="Top Languages" />
+  <img height=200 align="center" src="https://github-readme-streak-stats.herokuapp.com/?user=lacymorrow&theme=transparent" alt="GitHub Streak" />
 </a>
+
+**F) Profile Summary — Repos per Language**
+<a href="https://github.com/lacymorrow/">
+  <img height=200 align="center" src="https://raw.githubusercontent.com/lacymorrow/lacymorrow/profile-summary-cards/profile-summary-card-output/default/1-repos-per-language.svg" alt="Repos per Language" />
+</a>
+
+**G) Profile Summary — Commits per Language**
+<a href="https://github.com/lacymorrow/">
+  <img height=200 align="center" src="https://raw.githubusercontent.com/lacymorrow/lacymorrow/profile-summary-cards/profile-summary-card-output/default/2-most-commit-language.svg" alt="Commits per Language" />
+</a>
+
+**H) Profile Summary — Productive Time**
 <a href="https://github.com/lacymorrow/">
   <img height=200 align="center" src="https://raw.githubusercontent.com/lacymorrow/lacymorrow/profile-summary-cards/profile-summary-card-output/default/4-productive-time.svg" alt="Productive Time" />
+</a>
+
+**I) GitHub Activity Graph**
+
+![Activity Graph](https://github-readme-activity-graph.vercel.app/graph?username=lacymorrow&theme=github-compact)
+
+**J) GitHub Stats (github-readme-stats alternate host — may work)**
+<a href="https://github.com/lacymorrow/">
+  <img height=200 align="center" src="https://github-readme-stats-sigma-five.vercel.app/api?username=lacymorrow&show_icons=true&theme=transparent" alt="Stats" />
+</a>
+
+**K) Top Languages (github-readme-stats alternate host)**
+<a href="https://github.com/lacymorrow/">
+  <img height=200 align="center" src="https://github-readme-stats-sigma-five.vercel.app/api/top-langs/?username=lacymorrow&layout=compact&langs_count=8&card_width=320&theme=transparent&hide=PHP" alt="Top Langs" />
 </a>

--- a/src/components/layout/nav.tsx
+++ b/src/components/layout/nav.tsx
@@ -5,6 +5,7 @@ const navigation = [
   { name: "Play", href: "/play" },
   { name: "About", href: "/about" },
   { name: "Contact", href: "/contact" },
+  { name: "Colophon", href: "/about/colophon" },
   { name: "Fly5 ↗", href: "https://fly5.live" },
 ];
 

--- a/src/pages/about/_meta.json
+++ b/src/pages/about/_meta.json
@@ -36,6 +36,12 @@
       "pagination": false
     }
   },
+  "colophon": {
+    "theme": {
+      "pagination": false,
+      "typesetting": "article"
+    }
+  },
   "archive": {
     "title": "Archive",
     "display": "hidden"

--- a/src/pages/about/colophon.mdx
+++ b/src/pages/about/colophon.mdx
@@ -1,0 +1,33 @@
+---
+title: Colophon
+---
+
+# Colophon
+
+This site is designed, built, and maintained by **Lacy Morrow**.
+
+## Stack
+
+- **Framework** — [Next.js](https://nextjs.org) with [Nextra](https://nextra.site) for MDX-powered docs and content
+- **Language** — TypeScript
+- **Styling** — [Tailwind CSS](https://tailwindcss.com) + [Radix UI](https://radix-ui.com) primitives
+- **Animation** — [Framer Motion](https://www.framer.com/motion/)
+- **3D** — [React Three Fiber](https://docs.pmnd.rs/react-three-fiber) + [View3D](https://naver.github.io/egjs-view3d/)
+- **Code Embeds** — [Sandpack](https://sandpack.codesandbox.io/)
+- **Hosting** — [Vercel](https://vercel.com)
+
+## Typography
+
+System font stack. Fast, native, zero layout shift.
+
+## Design Philosophy
+
+Minimal chrome, maximum content. The site is a portfolio and playground — every page should load fast and get out of the way. Interactive experiments live under [/play](/play), client work under [/work](/work).
+
+## Source
+
+The source code for this site is open on [GitHub](https://github.com/lacymorrow/lacymorrow).
+
+## Contact
+
+Questions, bugs, or just want to say hi → [/contact](/contact)

--- a/src/pages/about/colophon.mdx
+++ b/src/pages/about/colophon.mdx
@@ -12,7 +12,6 @@ This site is designed, built, and maintained by **Lacy Morrow**.
 - **Language** — TypeScript
 - **Styling** — [Tailwind CSS](https://tailwindcss.com) + [Radix UI](https://radix-ui.com) primitives
 - **Animation** — [Framer Motion](https://www.framer.com/motion/)
-- **3D** — [React Three Fiber](https://docs.pmnd.rs/react-three-fiber) + [View3D](https://naver.github.io/egjs-view3d/)
 - **Code Embeds** — [Sandpack](https://sandpack.codesandbox.io/)
 - **Hosting** — [Vercel](https://vercel.com)
 
@@ -22,7 +21,7 @@ System font stack. Fast, native, zero layout shift.
 
 ## Design Philosophy
 
-Minimal chrome, maximum content. The site is a portfolio and playground — every page should load fast and get out of the way. Interactive experiments live under [/play](/play), client work under [/work](/work).
+Portfolio and playground. Interactive experiments live under [/play](/play), client work under [/work](/work).
 
 ## Source
 

--- a/src/pages/about/colophon.mdx
+++ b/src/pages/about/colophon.mdx
@@ -17,11 +17,11 @@ This site is designed, built, and maintained by **Lacy Morrow**.
 
 ## Typography
 
-System font stack. Fast, native, zero layout shift.
+System font stack — whatever your OS ships.
 
-## Design Philosophy
+## Design
 
-Portfolio and playground. Interactive experiments live under [/play](/play), client work under [/work](/work).
+Half portfolio, half playground. Experiments go in [/play](/play), work history in [/work](/work).
 
 ## Source
 


### PR DESCRIPTION
Adds a colophon page at `/about/colophon` describing the site's tech stack, design philosophy, and source.

**Changes:**
- `src/pages/about/colophon.mdx` — new colophon page (Next.js, Nextra, Tailwind, Radix, Framer Motion, R3F, Sandpack, Vercel)
- `src/pages/about/_meta.json` — registered with article typesetting
- `src/components/layout/nav.tsx` — added Colophon link to footer nav