### PR TITLE
fix: add all client pages to nav, exclude hidden pages from sitemap

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,6 +1,6 @@
 /** @type {import('next-sitemap').IConfig} */
 module.exports = {
   siteUrl: process.env.SITE_URL || 'https://www.lacymorrow.com',
-  generateRobotsTxt: true, // (optional)
-  // ...other options
+  generateRobotsTxt: true,
+  exclude: ['/sink', '/lacy', '/404'],
 }

--- a/src/pages/work/clients/_meta.json
+++ b/src/pages/work/clients/_meta.json
@@ -1,5 +1,22 @@
 {
+  "invision": "InVision",
+  "innovation-works": "Innovation Works",
+  "cosmic-cart": "Cosmic Cart",
   "space-monkey-films": "Space Monkey Films",
+  "mission-film-works": "Mission Film Works",
+  "phase2-productions": "Phase2 Productions",
   "charlies-vision": "Charlie's Vision",
-  "susan-morrow": "Susan Morrow"
+  "susan-morrow": "Susan Morrow",
+  "nancy-nicholson": "Nancy Nicholson",
+  "rae-images": "Rae Images",
+  "right-hand-editing": "Right Hand Editing",
+  "effective-media-solutions": "Effective Media Solutions",
+  "college-career-advisors": "College Career Advisors",
+  "boone-community-network": "Boone Community Network",
+  "all-seasons": "All Seasons",
+  "american-comfort": "American Comfort",
+  "blue-ribbon-recipes": "Blue Ribbon Recipes",
+  "hinson-mechanical": "Hinson Mechanical",
+  "iac-music": "IAC Music",
+  "patterson-heating-air": "Patterson Heating & Air"
 }


### PR DESCRIPTION
Fixes Ahrefs orphan pages warning (6 URLs).

- Added all 20 client pages to `work/clients/_meta.json` (only 3 were listed)
- Excluded `/sink`, `/lacy`, `/404` from sitemap (intentionally hidden pages)
- All pages are now either in navigation or excluded from sitemap