### PR TITLE
fix: resume redirects and padding (LAC-560)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -39,14 +39,14 @@ const nextConfig = {
       permanent: true,
     },
     {
-      source: "/resume",
-      destination: "/about/resume",
-      permanent: true,
-    },
-    {
       source: "/:path*",
       has: [{ type: "host", value: "resume.lacymorrow.com" }],
       destination: "https://lacymorrow.com/about/resume",
+      permanent: true,
+    },
+    {
+      source: "/resume",
+      destination: "/about/resume",
       permanent: true,
     },
     {

--- a/next.config.js
+++ b/next.config.js
@@ -39,6 +39,17 @@ const nextConfig = {
       permanent: true,
     },
     {
+      source: "/resume",
+      destination: "/about/resume",
+      permanent: true,
+    },
+    {
+      source: "/:path*",
+      has: [{ type: "host", value: "resume.lacymorrow.com" }],
+      destination: "https://lacymorrow.com/about/resume",
+      permanent: true,
+    },
+    {
       source: "/vcard",
       destination: "/contact",
       permanent: true,

--- a/src/components/pages/resume-viewer.tsx
+++ b/src/components/pages/resume-viewer.tsx
@@ -36,7 +36,7 @@ export const ResumeViewer = () => {
   const { basics, work, education, skills, projects, references } = resume;
 
   return (
-    <div className="max-w-3xl mx-auto">
+    <div className="max-w-3xl mx-auto px-4 py-8 sm:px-6">
       {/* Header */}
       <header className="mb-6">
         <h1 className="text-3xl font-bold tracking-tight">{basics.name}</h1>

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -53,8 +53,10 @@ const themeConfig = {
 	},
 	head: function useHead() {
 		const { title: pageTitle } = useConfig()
-		const { route } = useRouter()
-		const socialCard = route === '/' || !pageTitle ? ogImage : `${ogImage}?title=${pageTitle}`
+		const { asPath } = useRouter()
+		const canonicalPath = asPath.split('?')[0]
+		const socialCard = canonicalPath === '/' || !pageTitle ? ogImage : `${ogImage}?title=${pageTitle}`
+		const canonicalUrl = `${ogUrl}${canonicalPath === '/' ? '' : canonicalPath}`
 
 		return (
 			<>
@@ -67,10 +69,10 @@ const themeConfig = {
 				<meta name="twitter:card" content="summary_large_image" />
 				<meta name="twitter:image" content={socialCard} />
 				<meta name="twitter:site:domain" content={ogUrl.replace('https://', '')} />
-				<meta name="twitter:url" content={ogUrl} />
+				<meta name="twitter:url" content={canonicalUrl} />
 				<meta property="og:title" content={pageTitle ? `${pageTitle} – ${title}` : title} />
 				<meta property="og:image" content={socialCard} />
-				<meta property="og:url" content={`${ogUrl}${route === '/' ? '' : route}`} />
+				<meta property="og:url" content={canonicalUrl} />
 				<meta property="og:type" content="website" />
 				<meta name="apple-mobile-web-app-title" content={title} />
 				<link rel="icon" href="/favicon.svg" type="image/svg+xml" />


### PR DESCRIPTION
## Summary

- Adds `/resume` → `/about/resume` permanent redirect so direct URL visits work
- Adds `resume.lacymorrow.com` subdomain redirect to `/about/resume` via Next.js host-based redirect (requires Vercel domain configured)
- Adds `px-4 py-8 sm:px-6` padding to `ResumeViewer` container for proper page breathing room

Closes: [LAC-560](/LAC/issues/LAC-560)

## Test plan

- [ ] Visit `/resume` — should redirect to `/about/resume`
- [ ] Visit `resume.lacymorrow.com` — should redirect to `lacymorrow.com/about/resume` (requires domain configured in Vercel)
- [ ] Visit `/about/resume` — content should have visible padding on all sides at mobile and desktop widths