### PR TITLE
fix: upgrade internal URL to HTTPS in resume.json (LAC-1246)

### DIFF
--- a/src/data/resume.json
+++ b/src/data/resume.json
@@ -11,7 +11,7 @@
     "image": "https://avatars.githubusercontent.com/u/1311301?v=4",
     "email": "me@lacymorrow.com",
     "phone": "(704) 451-6680",
-    "url": "http://lacymorrow.com",
+    "url": "https://www.lacymorrow.com",
     "summary": "Over 20 years as a Web Developer building accessible, well-architected sites and apps. Creator of pixel-perfect, mobile-first development with graceful degradation and progressive enhancement.\n\nEXPERTISE: Agentic engineer + Full-stack developer + Hardware Engineer; Agency owner; Tech/Development lead; Product/Project manager; DevOps; IT consultant; Software architect; Hiring manager; SCRUM master\n\nI especially enjoy TypeScript, React, NextJS, and Electron/Tauri\n\nQUALITIES: Tech leader. Passionate about quality. Communicative and accessible; Reliable, confident, and eager to build. A highly motivated problem-solver.",
     "location": {
       "countryCode": "US",


### PR DESCRIPTION
## Summary

- Fixes AHREFS critical flag: `basics.url` in `src/data/resume.json` was `http://lacymorrow.com`
- Changed to `https://www.lacymorrow.com` to eliminate the mixed-content internal HTTP link
- Scanned all MDX content — remaining `http://` links are external third-party URLs (WayBack Machine, ticalc.org, etc.), not internal lacymorrow.com links

## Related

Paperclip issue: [LAC-1246](/LAC/issues/LAC-1246)
SEO triage source: [LAC-963](/LAC/issues/LAC-963)

## Test plan

- [ ] Build passes
- [ ] Resume page renders correctly at `/resume`
- [ ] No AHREFS internal HTTP link flag for `basics.url`