### PR TITLE
fix: resolve GSC 404 and duplicate canonical issues (LAC-1387)

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -11,7 +11,7 @@ export const Footer = () => {
           <div className="flex items-center">
             <Link
               className="hover:text-splash"
-              href="https://lacymorrow.com"
+              href="https://www.lacymorrow.com"
               target="_blank"
               rel="noopener"
             >

--- a/src/pages/_meta.json
+++ b/src/pages/_meta.json
@@ -63,5 +63,12 @@
     "theme": {
       "pagination": false
     }
+  },
+  "privacy": {
+    "title": "Privacy Policy",
+    "display": "hidden",
+    "theme": {
+      "pagination": false
+    }
   }
 }

--- a/src/pages/privacy.mdx
+++ b/src/pages/privacy.mdx
@@ -1,0 +1,53 @@
+---
+title: Privacy Policy
+description: Privacy policy for lacymorrow.com — how visitor data is collected, used, and protected.
+---
+
+# Privacy Policy
+
+_Last updated: April 21, 2026_
+
+## Overview
+
+This website, **lacymorrow.com**, is the personal portfolio of Lacy Morrow. I respect your privacy and am committed to being transparent about any data collected through this site.
+
+## Data Collection
+
+### Analytics
+
+This site uses [Umami](https://umami.is/), a privacy-focused, open-source analytics platform. Umami does not use cookies, does not collect personal data, and is fully compliant with GDPR, CCPA, and PECR. All data is aggregated and anonymous.
+
+### Contact Form
+
+When you submit the contact form, the following information is collected:
+
+- **Name** (optional)
+- **Email address** (optional)
+- **Phone number** (optional)
+- **Message content** (required)
+
+This information is sent directly to my email via [Resend](https://resend.com/) and is used solely to respond to your inquiry. It is not stored in a database, sold, or shared with third parties.
+
+### Hosting
+
+This site is hosted on [Vercel](https://vercel.com/). Vercel may collect standard server logs including IP addresses and request metadata as part of their infrastructure. See [Vercel's Privacy Policy](https://vercel.com/legal/privacy-policy) for details.
+
+## Cookies
+
+This site does **not** use cookies for tracking or advertising purposes. No third-party cookies are set.
+
+## Third-Party Links
+
+This site contains links to external websites. I am not responsible for the privacy practices of those sites. I encourage you to read their privacy policies.
+
+## Your Rights
+
+You have the right to:
+
+- Request information about any data associated with you
+- Request deletion of any data associated with you
+- Opt out of analytics (Umami respects Do Not Track headers)
+
+## Contact
+
+If you have questions about this privacy policy, please [contact me](/contact).

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -8,7 +8,7 @@ import { useConfig } from 'nextra-theme-docs';
 const title = "Lacy Morrow";
 const description = "Lacy Morrow is a leading web and software engineer, UAV operator, and the creator of Crossover and other open-source projects.";
 const ogImage = "https://lacy.is/api/og";
-const ogUrl = "https://lacymorrow.com";
+const ogUrl = "https://www.lacymorrow.com";
 const githubUrl = 'https://github.com/lacymorrow/';
 
 const themeConfig = {
@@ -74,6 +74,7 @@ const themeConfig = {
 				<meta property="og:url" content={canonicalUrl} />
 				<meta property="og:type" content="website" />
 				<meta name="apple-mobile-web-app-title" content={title} />
+				<link rel="canonical" href={canonicalUrl} />
 				<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
 				<link rel="icon" href="/favicon.png" type="image/png" />
 				<link rel="icon" href="/favicon-dark.svg" type="image/svg+xml" media="(prefers-color-scheme: dark)" />


### PR DESCRIPTION
## Summary

Fixes two Google Search Console issues flagged 2026-05-14 that were blocking sitemap page indexing on lacymorrow.com.

**Root causes found and fixed:**

- **Missing `<link rel="canonical">` tag**: `theme.config.jsx` computed `canonicalUrl` but only rendered it as `og:url` meta property — never as the actual HTML canonical link tag that Google reads for duplicate-content resolution.
- **www vs non-www mismatch**: Sitemap used `https://www.lacymorrow.com` (set in `next-sitemap.config.js` via a prior fix to eliminate 95 redirects) but `ogUrl` was still `https://lacymorrow.com`. Google saw both domain variants with no canonical signal, causing "duplicate without user-selected canonical" for every page.
- **Undeployed privacy page**: `privacy.mdx` existed locally but was untracked — local sitemap builds included `/privacy` but production lacked the page, causing 404s for any crawl following the sitemap.

**Changes:**
- `theme.config.jsx`: Changed `ogUrl` to `https://www.lacymorrow.com`; added `<link rel="canonical" href={canonicalUrl} />`
- `src/pages/_meta.json`: Added hidden `privacy` entry so Nextra recognizes the page
- `src/pages/privacy.mdx`: Committed the privacy policy page (was untracked)

**After deploy:** Regenerate and resubmit sitemap to GSC via the Search Console UI.

## Paperclip issue

[LAC-1387](/LAC/issues/LAC-1387)

## Test plan

- [ ] Verify `<link rel="canonical" href="https://www.lacymorrow.com/...">` appears in page source on production
- [ ] Confirm `https://www.lacymorrow.com/privacy` returns 200 after deploy
- [ ] Confirm sitemap at `/sitemap.xml` still lists all expected pages under `www.lacymorrow.com`
- [ ] Resubmit sitemap in GSC and verify no new canonical/404 errors appear