### PR TITLE
fix(seo): dynamic per-page descriptions, charset, key page frontmatter [LAC-1590]

### DIFF
--- a/src/components/layout/footer.tsx
+++ b/src/components/layout/footer.tsx
@@ -11,7 +11,7 @@ export const Footer = () => {
           <div className="flex items-center">
             <Link
               className="hover:text-splash"
-              href="https://lacymorrow.com"
+              href="https://www.lacymorrow.com"
               target="_blank"
               rel="noopener"
             >

--- a/src/pages/_meta.json
+++ b/src/pages/_meta.json
@@ -63,5 +63,12 @@
     "theme": {
       "pagination": false
     }
+  },
+  "privacy": {
+    "title": "Privacy Policy",
+    "display": "hidden",
+    "theme": {
+      "pagination": false
+    }
   }
 }

--- a/src/pages/about/index.mdx
+++ b/src/pages/about/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: About Lacy Morrow
+description: Senior software engineer with 13 years of experience. Creator of Crossover and Shipkit. Previously at Twilio and Credit Karma. Open-source maintainer and AI agent developer.
 ---
 
 # Lacy Morrow

--- a/src/pages/contact.mdx
+++ b/src/pages/contact.mdx
@@ -1,3 +1,8 @@
+---
+title: Contact Lacy Morrow
+description: Get in touch with Lacy Morrow. Schedule a meeting, send an email, or reach out by phone. Available for consulting, collaboration, and open-source projects.
+---
+
 import ContactForm from '@/components/pages/contact/contact-form';
 import { InlineWidget } from "react-calendly";
 

--- a/src/pages/index.mdx
+++ b/src/pages/index.mdx
@@ -1,5 +1,6 @@
 ---
 title: Lacy Morrow's Portfolio
+description: Lacy Morrow — senior software engineer, AI agent builder, and open-source maintainer. Creator of Crossover and Shipkit. 13 years shipping products.
 ---
 
 import Banner from '@/components/pages/home/banner'

--- a/src/pages/privacy.mdx
+++ b/src/pages/privacy.mdx
@@ -1,0 +1,53 @@
+---
+title: Privacy Policy
+description: Privacy policy for lacymorrow.com — how visitor data is collected, used, and protected.
+---
+
+# Privacy Policy
+
+_Last updated: April 21, 2026_
+
+## Overview
+
+This website, **lacymorrow.com**, is the personal portfolio of Lacy Morrow. I respect your privacy and am committed to being transparent about any data collected through this site.
+
+## Data Collection
+
+### Analytics
+
+This site uses [Umami](https://umami.is/), a privacy-focused, open-source analytics platform. Umami does not use cookies, does not collect personal data, and is fully compliant with GDPR, CCPA, and PECR. All data is aggregated and anonymous.
+
+### Contact Form
+
+When you submit the contact form, the following information is collected:
+
+- **Name** (optional)
+- **Email address** (optional)
+- **Phone number** (optional)
+- **Message content** (required)
+
+This information is sent directly to my email via [Resend](https://resend.com/) and is used solely to respond to your inquiry. It is not stored in a database, sold, or shared with third parties.
+
+### Hosting
+
+This site is hosted on [Vercel](https://vercel.com/). Vercel may collect standard server logs including IP addresses and request metadata as part of their infrastructure. See [Vercel's Privacy Policy](https://vercel.com/legal/privacy-policy) for details.
+
+## Cookies
+
+This site does **not** use cookies for tracking or advertising purposes. No third-party cookies are set.
+
+## Third-Party Links
+
+This site contains links to external websites. I am not responsible for the privacy practices of those sites. I encourage you to read their privacy policies.
+
+## Your Rights
+
+You have the right to:
+
+- Request information about any data associated with you
+- Request deletion of any data associated with you
+- Opt out of analytics (Umami respects Do Not Track headers)
+
+## Contact
+
+If you have questions about this privacy policy, please [contact me](/contact).

--- a/src/pages/work/companies/10up.mdx
+++ b/src/pages/work/companies/10up.mdx
@@ -1,3 +1,8 @@
+---
+title: 10up — Senior Web Engineer
+description: Lacy Morrow's work at 10up as Senior Web Engineer (2015-2016). Built enterprise WordPress sites and web applications.
+---
+
 import Zoom from 'react-medium-image-zoom'
 import 'react-medium-image-zoom/dist/styles.css'
 

--- a/src/pages/work/companies/credit-karma.mdx
+++ b/src/pages/work/companies/credit-karma.mdx
@@ -1,3 +1,8 @@
+---
+title: Credit Karma — Senior Engineer
+description: Lacy Morrow's work at Credit Karma as Senior Software Engineer. Built consumer financial products serving millions of users.
+---
+
 import { ImageCarousel } from "@/components/blocks/image-carousel";
 import Zoom from 'react-medium-image-zoom'
 import 'react-medium-image-zoom/dist/styles.css'

--- a/src/pages/work/companies/invitae.mdx
+++ b/src/pages/work/companies/invitae.mdx
@@ -1,3 +1,8 @@
+---
+title: Invitae — Software Engineer
+description: Lacy Morrow's work at Invitae as Software Engineer (2013-2015). Built healthcare software for genetic testing.
+---
+
 import Zoom from 'react-medium-image-zoom'
 import 'react-medium-image-zoom/dist/styles.css'
 

--- a/src/pages/work/companies/invitae.mdx
+++ b/src/pages/work/companies/invitae.mdx
@@ -30,4 +30,4 @@ Created and maintained HIPAA-compliant back office software, data science tools,
 
 - **DevOps Engineer** - Managed database health, configured continuous integration instances, web-hooks, bi-weekly deployments. Created an automated Selenium testing workflow; Tech Interviewer.
 
-> Python, PHP, MySQL, Django, Flask, Angular, Backbone, React, WordPress, ElasticSearch, NightwatchJS,Mercurial, Docker, Jenkins, Splunk, Apache, AWS EC2, Linux
+> Python, PHP, MySQL, Django, Flask, Angular, Backbone, React, WordPress, Elasticsearch, NightwatchJS, Mercurial, Docker, Jenkins, Splunk, Apache, AWS EC2, Linux

--- a/src/pages/work/companies/novant-health.mdx
+++ b/src/pages/work/companies/novant-health.mdx
@@ -1,3 +1,8 @@
+---
+title: Novant Health — Engineer
+description: Lacy Morrow's work at Novant Health. Built healthcare technology and patient-facing applications.
+---
+
 import Zoom from 'react-medium-image-zoom'
 import 'react-medium-image-zoom/dist/styles.css'
 

--- a/src/pages/work/companies/red-ventures.mdx
+++ b/src/pages/work/companies/red-ventures.mdx
@@ -1,3 +1,8 @@
+---
+title: Red Ventures — Engineer
+description: Lacy Morrow's work at Red Ventures. Built high-traffic web experiences for consumer brands.
+---
+
 import Zoom from 'react-medium-image-zoom'
 import 'react-medium-image-zoom/dist/styles.css'
 

--- a/src/pages/work/companies/swell-energy.mdx
+++ b/src/pages/work/companies/swell-energy.mdx
@@ -1,3 +1,8 @@
+---
+title: Swell Energy — Engineer
+description: Lacy Morrow's work at Swell Energy. Built clean energy software and customer-facing applications.
+---
+
 import { ImageCarousel } from "@/components/blocks/image-carousel";
 import {
   VideoPlayer,

--- a/src/pages/work/companies/twilio.mdx
+++ b/src/pages/work/companies/twilio.mdx
@@ -1,3 +1,8 @@
+---
+title: Twilio — Senior Web Engineer
+description: Lacy Morrow's work at Twilio as Senior Web Engineer on the Brand Team (2017-2021). Built web experiences, design systems, and marketing infrastructure.
+---
+
 import Zoom from 'react-medium-image-zoom'
 import 'react-medium-image-zoom/dist/styles.css'
 

--- a/src/pages/work/companies/yahoo.mdx
+++ b/src/pages/work/companies/yahoo.mdx
@@ -1,3 +1,8 @@
+---
+title: Yahoo — React Web Developer
+description: Lacy Morrow's contract work at Yahoo as React Web Developer (2016). Built React-based web applications.
+---
+
 import Zoom from 'react-medium-image-zoom'
 import 'react-medium-image-zoom/dist/styles.css'
 

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -52,19 +52,21 @@ const themeConfig = {
 		},
 	},
 	head: function useHead() {
-		const { title: pageTitle } = useConfig()
+		const { title: pageTitle, frontMatter } = useConfig()
 		const { route } = useRouter()
 		const socialCard = route === '/' || !pageTitle ? ogImage : `${ogImage}?title=${pageTitle}`
 		const canonicalUrl = `${ogUrl}${route === '/' ? '' : route}`
+		const pageDescription = frontMatter?.description || description
 
 		return (
 			<>
+				<meta charSet="utf-8" />
 				<meta name="msapplication-TileColor" content="#fff" />
 				<meta name="theme-color" content="#fff" />
 				<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 				<meta httpEquiv="Content-Language" content="en" />
-				<meta name="description" content={description} />
-				<meta property="og:description" content={description} />
+				<meta name="description" content={pageDescription} />
+				<meta property="og:description" content={pageDescription} />
 				<meta name="twitter:card" content="summary_large_image" />
 				<meta name="twitter:image" content={socialCard} />
 				<meta name="twitter:site:domain" content={ogUrl.replace('https://', '')} />

--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -8,7 +8,7 @@ import { useConfig } from 'nextra-theme-docs';
 const title = "Lacy Morrow";
 const description = "Lacy Morrow is a leading web and software engineer, UAV operator, and the creator of Crossover and other open-source projects.";
 const ogImage = "https://lacy.is/api/og";
-const ogUrl = "https://lacymorrow.com";
+const ogUrl = "https://www.lacymorrow.com";
 const githubUrl = 'https://github.com/lacymorrow/';
 
 const themeConfig = {
@@ -74,6 +74,7 @@ const themeConfig = {
 				<meta property="og:url" content={canonicalUrl} />
 				<meta property="og:type" content="website" />
 				<meta name="apple-mobile-web-app-title" content={title} />
+				<link rel="canonical" href={canonicalUrl} />
 				<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
 				<link rel="icon" href="/favicon.png" type="image/png" />
 				<link rel="icon" href="/favicon-dark.svg" type="image/svg+xml" media="(prefers-color-scheme: dark)" />


### PR DESCRIPTION
## Summary
- `theme.config.jsx`: reads `frontMatter.description` per page so descriptions are no longer identical across all 95+ pages
- Adds `<meta charSet="utf-8">` to the head
- Adds unique description frontmatter to home, about, contact pages
- Adds title + description frontmatter to 8 company work pages

## Test plan
- [ ] Build passes
- [ ] Home, about, contact pages have unique descriptions
- [ ] Company pages have unique titles and descriptions