### PR TITLE
fix(seo): remove duplicate meta description tag [LAC-1838]

### DIFF
--- a/theme.config.jsx
+++ b/theme.config.jsx
@@ -26,8 +26,10 @@ const themeConfig = {
 	},
 	useNextSeoProps() {
 		const { asPath } = useRouter()
-		if (asPath === '/') return { titleTemplate: title }
-		return { titleTemplate: `%s – ${title}` }
+		const { frontMatter } = useConfig()
+		const pageDescription = frontMatter?.description || description
+		if (asPath === '/') return { titleTemplate: title, description: pageDescription }
+		return { titleTemplate: `%s – ${title}`, description: pageDescription }
 	},
 	project: { link: githubUrl },
 	chat: {
@@ -90,7 +92,6 @@ const themeConfig = {
 				<meta name="theme-color" content="#fff" />
 				<meta name="viewport" content="width=device-width, initial-scale=1.0" />
 				<meta httpEquiv="Content-Language" content="en" />
-				<meta name="description" content={pageDescription} />
 				<meta property="og:description" content={pageDescription} />
 				<meta name="twitter:card" content="summary_large_image" />
 				<meta name="twitter:image" content={socialCard} />


### PR DESCRIPTION
## Summary

- **Root cause**: Nextra v2 (`nextra-theme-docs`) automatically passes `frontMatter.description` to its internal `<NextSeo>` component, rendering `<meta name="description">`. The `head()` function in `theme.config.jsx` was *also* explicitly rendering `<meta name="description" content={pageDescription} />` — causing a duplicate on every page with a frontmatter `description` field (12 pages).
- **Fix**: Removed `<meta name="description">` from `head()`. Moved the description (with default fallback for pages lacking frontmatter descriptions) into `useNextSeoProps()` so NextSeo is the single source of truth.
- `<meta property="og:description">` remains in `head()` — NextSeo does not auto-set this, so no duplicate risk there.

## Pages previously affected (all with `description:` frontmatter)

`index.mdx`, `contact.mdx`, `privacy.mdx`, `about/index.mdx`, `work/companies/10up.mdx`, `work/companies/credit-karma.mdx`, `work/companies/swell-energy.mdx`, `work/companies/yahoo.mdx`, `work/companies/twilio.mdx`, `work/companies/red-ventures.mdx`, `work/companies/invitae.mdx`, `work/companies/novant-health.mdx`

## Related

Paperclip issue: [LAC-1838](/LAC/issues/LAC-1838)

## Test plan

- [ ] Start dev server (`pnpm dev`) and view-source any page with frontmatter description (e.g., `/contact`, `/`) — confirm exactly one `<meta name="description">` tag
- [ ] Check a page without frontmatter description (e.g., `/work/clients/all-seasons`) — confirm the default description is rendered
- [ ] Confirm `og:description` is still present on all pages