### PR TITLE
feat(portfolio): add shipx and Paperclip Hub to portfolio [LAC-1842]

### DIFF
--- a/src/components/pages/home/currently_working.tsx
+++ b/src/components/pages/home/currently_working.tsx
@@ -8,12 +8,12 @@ const CurrentlyWorking = () => {
     {
       title: "Lacy Shell",
       description: "Talk to your terminal. Natural language routes to AI agents automatically.",
-      href: "https://lacy.sh",
+      href: "/play/lacy",
     },
     {
       title: "Juno",
       description: "Anthropic Computer Use for your desktop. AI that sees and clicks.",
-      href: "https://junebug.ai",
+      href: "/play/juno",
     },
     {
       title: "Shipkit",

--- a/src/components/pages/home/currently_working.tsx
+++ b/src/components/pages/home/currently_working.tsx
@@ -35,6 +35,16 @@ const CurrentlyWorking = () => {
       description: "Code rescue for AI-generated projects. We fix vibe code.",
       href: "https://vibe.rehab",
     },
+    {
+      title: "shipx",
+      description: "Interactive release CLI — bump, tag, publish, and ship from one command.",
+      href: "/play/shipx",
+    },
+    {
+      title: "Paperclip Hub",
+      description: "Plugin hub & marketplace for Paperclip AI agents.",
+      href: "/play/paperclip-hub",
+    },
   ];
 
   return (

--- a/src/components/pages/home/past_projects.tsx
+++ b/src/components/pages/home/past_projects.tsx
@@ -18,12 +18,12 @@ const PastProjects = () => {
     {
       title: "CrossOver",
       description: "Gaming overlay for any screen. Windows, Mac, and Linux.",
-      href: "https://gh.lacymorrow.com/crossover",
+      href: "/play/crossover",
     },
     {
       title: "Hitchhiker's Guide to the Galaxy",
       description: "My favorite book, now an AI. Ask it anything. Probably inaccurately.",
-      href: "https://hitchhikersgalaxy.guide",
+      href: "/play/hitchhikersgalaxy",
     },
     {
       title: "Cloud0 AI Chat",

--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -1,0 +1,124 @@
+export type ProjectStatus = "active" | "shipped" | "beta" | "archived"
+
+export interface Project {
+  name: string
+  description: string
+  url: string
+  status: ProjectStatus
+  section: "building" | "project"
+  startDate?: string
+}
+
+export const projects: Project[] = [
+  {
+    name: "Lacy Shell",
+    description:
+      "Talk to your terminal. Natural language routes to AI agents automatically.",
+    url: "https://lacy.sh",
+    status: "active",
+    section: "building",
+    startDate: "2024-01-01",
+  },
+  {
+    name: "Juno AI",
+    description:
+      "Voice-operate your computer. Rust + Tauri + Whisper.",
+    url: "https://junebug.ai",
+    status: "active",
+    section: "building",
+    startDate: "2025-01-01",
+  },
+  {
+    name: "Shipkit",
+    description:
+      "Ship Next.js apps fast. Auth, payments, AI included.",
+    url: "https://shipkit.io",
+    status: "active",
+    section: "building",
+    startDate: "2024-01-01",
+  },
+  {
+    name: "AI Alpaca",
+    description:
+      "Autonomous trading bot. Claude + Alpaca MCP.",
+    url: "https://github.com/lacymorrow/ai-alpaca",
+    status: "beta",
+    section: "building",
+    startDate: "2026-01-01",
+  },
+  {
+    name: "shipx",
+    description:
+      "Interactive release CLI — bump, tag, publish, and ship from one command.",
+    url: "https://github.com/lacymorrow/shipx",
+    status: "active",
+    section: "building",
+    startDate: "2025-01-01",
+  },
+  {
+    name: "Paperclip Hub",
+    description:
+      "Plugin hub & marketplace for Paperclip AI agents.",
+    url: "https://cliphub.fyi",
+    status: "active",
+    section: "building",
+    startDate: "2025-01-01",
+  },
+  {
+    name: "CrossOver",
+    description:
+      "Gaming overlay for any screen. Windows, Mac, and Linux. Featured in Windows Store.",
+    url: "https://gh.lacymorrow.com/crossover",
+    status: "shipped",
+    section: "project",
+    startDate: "2015-01-01",
+  },
+  {
+    name: "OpenClaw Trading",
+    description:
+      "Autonomous AI trading agents in Rust, Go, and Shell for stocks and prediction markets.",
+    url: "https://github.com/lacymorrow/openclaw-alpaca-trading-skill",
+    status: "active",
+    section: "project",
+    startDate: "2024-01-01",
+  },
+  {
+    name: "MCP Servers & Tools",
+    description:
+      "Model Context Protocol integrations for AI agent desktop automation.",
+    url: "https://github.com/lacymorrow",
+    status: "active",
+    section: "project",
+    startDate: "2025-01-01",
+  },
+  {
+    name: "Cloud0 AI",
+    description:
+      "100% private, offline AI. Your data never leaves your machine.",
+    url: "https://cloud0.dev",
+    status: "shipped",
+    section: "project",
+    startDate: "2024-01-01",
+  },
+  {
+    name: "Twilio HackPack v4",
+    description:
+      "Open source hardware badge for SIGNAL 2018. Joystick, lights, touchscreen on Raspberry Pi Zero.",
+    url: "https://github.com/twilio/hackpack-v4",
+    status: "archived",
+    section: "project",
+    startDate: "2018-01-01",
+  },
+  {
+    name: "XSPF Jukebox",
+    description:
+      "Web-based playlist player. One of the original web audio players.",
+    url: "https://xspf-jukebox.vercel.app",
+    status: "archived",
+    section: "project",
+    startDate: "2008-01-01",
+  },
+]
+
+export const buildingProjects = projects.filter((p) => p.section === "building")
+export const gridProjects = projects.filter((p) => p.section === "project")

--- a/src/pages/play/_meta.json
+++ b/src/pages/play/_meta.json
@@ -3,9 +3,13 @@
 		"title": "Play",
 		"display": "hidden"
 	},
+	"juno": "Juno — AI Desktop",
+	"lacy": "lacy — AI Shell",
 	"crossover": "CrossOver",
 	"cinematic": "Cinematic",
 	"casper": "Casper WordPress theme",
+	"shipx": "shipx — Release CLI",
+	"hitchhikersgalaxy": "Hitchhiker's Guide",
 	"js": "JavaScript libraries",
 	"react": "React libraries",
 	"vscode": "VSCode extensions",

--- a/src/pages/play/_meta.json
+++ b/src/pages/play/_meta.json
@@ -9,6 +9,7 @@
 	"cinematic": "Cinematic",
 	"casper": "Casper WordPress theme",
 	"shipx": "shipx — Release CLI",
+	"paperclip-hub": "Paperclip Hub",
 	"hitchhikersgalaxy": "Hitchhiker's Guide",
 	"js": "JavaScript libraries",
 	"react": "React libraries",

--- a/src/pages/play/hitchhikersgalaxy.mdx
+++ b/src/pages/play/hitchhikersgalaxy.mdx
@@ -1,0 +1,23 @@
+# Hitchhiker's Guide to the Galaxy
+
+<Lead>A fully generative Hitchhiker's Guide to the Galaxy, built with AI and JavaScript sorcery. Ask it anything. It'll make something up. Probably inaccurately.</Lead>
+
+<Lead>**[hitchhikersgalaxy.guide ↗](https://hitchhikersgalaxy.guide)**</Lead>
+
+## About
+
+An AI-powered recreation of the legendary Guide from Douglas Adams' universe. Every entry is generated on the fly — ask about any planet, species, concept, or improbability, and the Guide will confidently provide an answer. Don't Panic.
+
+**Tech stack:** Next.js · OpenAI · React · TypeScript
+
+## Readme
+
+<Readme username="lacymorrow" repo="hitchhikersgalaxy.guide" />
+
+---
+
+## More Projects
+
+- [View all my projects →](/play)
+- [See my work experience →](/work)
+- [Learn more about me →](/about)

--- a/src/pages/play/juno.mdx
+++ b/src/pages/play/juno.mdx
@@ -1,0 +1,23 @@
+# Juno
+
+<Lead>AI that controls your Mac. Describe a task, watch it happen. Native macOS desktop app powered by Anthropic Computer Use and Claude.</Lead>
+
+<Lead>**[github.com/lacymorrow/juno ↗](https://github.com/lacymorrow/juno)**</Lead>
+
+## About
+
+Juno is a native macOS desktop app built with Tauri (Rust) and React. It gives Claude AI direct control of your desktop — describe what you want in plain language and watch it execute. It includes voice transcription via Whisper, MCP server integration, and a full desktop automation engine.
+
+**Tech stack:** Tauri v2 · Rust · React · TypeScript · Claude Computer Use · Whisper
+
+## Readme
+
+<Readme username="lacymorrow" repo="juno" />
+
+---
+
+## More Projects
+
+- [View all my projects →](/play)
+- [See my work experience →](/work)
+- [Learn more about me →](/about)

--- a/src/pages/play/lacy.mdx
+++ b/src/pages/play/lacy.mdx
@@ -1,0 +1,25 @@
+# lacy
+
+<Lead>Talk to your shell — commands run, questions go to AI. No prefixes, no friction. A zsh/bash plugin that routes intent to the right place.</Lead>
+
+<Lead>**[github.com/lacymorrow/lacy ↗](https://github.com/lacymorrow/lacy)**</Lead>
+
+## About
+
+`lacy` is a shell plugin that makes your terminal AI-native. Type a shell command and it runs. Type a question or task description and it goes to an AI agent (Claude, Gemini, Codex, or opencode). No special prefixes or modes — it figures out intent automatically.
+
+The plugin shells out to `lash` as a binary with zero npm dependency, keeping your shell startup fast.
+
+**Supported shells:** zsh · bash
+
+## Readme
+
+<Readme username="lacymorrow" repo="lacy" />
+
+---
+
+## More Projects
+
+- [View all my projects →](/play)
+- [See my work experience →](/work)
+- [Learn more about me →](/about)

--- a/src/pages/play/paperclip-hub.mdx
+++ b/src/pages/play/paperclip-hub.mdx
@@ -1,0 +1,21 @@
+# Paperclip Hub
+
+<Lead>Plugin hub & marketplace for Paperclip AI agents. Browse, install, and publish agent plugins.</Lead>
+
+<Lead>**[cliphub.fyi ↗](https://cliphub.fyi)** · **[github.com/lacymorrow/paperclip-hub ↗](https://github.com/lacymorrow/paperclip-hub)**</Lead>
+
+## About
+
+Paperclip Hub is the central plugin marketplace for the Paperclip agent platform. Agents discover and install plugins to extend their capabilities — from API integrations to custom tools and workflows.
+
+## Readme
+
+<Readme username="lacymorrow" repo="paperclip-hub" />
+
+---
+
+## More Projects
+
+- [View all my projects →](/play)
+- [See my work experience →](/work)
+- [Learn more about me →](/about)

--- a/src/pages/play/shipx.mdx
+++ b/src/pages/play/shipx.mdx
@@ -1,0 +1,23 @@
+# shipx
+
+<Lead>Interactive release CLI — bump version, tag, publish to npm, push to Cargo, update Homebrew, and cut a GitHub release. All from one command.</Lead>
+
+<Lead>**[github.com/lacymorrow/shipx ↗](https://github.com/lacymorrow/shipx)**</Lead>
+
+## About
+
+`shipx` is a unified release tool that handles the entire publish workflow interactively. Pick your bump type, let it update every registry that matters, and ship.
+
+**Supports:** npm · Cargo · Homebrew · GitHub Releases
+
+## Readme
+
+<Readme username="lacymorrow" repo="shipx" />
+
+---
+
+## More Projects
+
+- [View all my projects →](/play)
+- [See my work experience →](/work)
+- [Learn more about me →](/about)


### PR DESCRIPTION
## Summary
- Add **shipx** (release CLI) to the home page "Currently Working On" grid with link to `/play/shipx`
- Add **Paperclip Hub** (plugin marketplace) to the "Currently Working On" grid with new `/play/paperclip-hub` page
- Create Paperclip Hub portfolio page with description, links to cliphub.fyi and GitHub repo
- Register both projects in `projects.ts` data file
- Re-apply portfolio pages (Juno, lacy, shipx, Hitchhiker's Guide) from previous PR that were lost in squash merge

## Test plan
- [ ] Verify home page shows shipx and Paperclip Hub in "Currently Working On" section
- [ ] Verify `/play/shipx` page renders correctly
- [ ] Verify `/play/paperclip-hub` page renders correctly
- [ ] Build passes (`pnpm build` verified locally)