### PR TITLE
fix(seo): exclude orphan pages from sitemap [LAC-1247]

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -2,5 +2,34 @@
 module.exports = {
   siteUrl: process.env.SITE_URL || 'https://www.lacymorrow.com',
   generateRobotsTxt: true,
-  exclude: ['/sink', '/lacy', '/404'],
+  exclude: [
+    '/sink',
+    '/lacy',
+    '/404',
+    // Archive pages: kept for permalinks but not part of the active site
+    '/about/archive/*',
+    // Uncurated art experiments (only the ones in play/art/_meta.json are indexed)
+    '/play/art/blank',
+    '/play/art/continual',
+    '/play/art/converge',
+    '/play/art/lines',
+    '/play/art/multi',
+    '/play/art/offset',
+    '/play/art/orbit',
+    '/play/art/scribble',
+    '/play/art/scribe',
+    '/play/art/shine',
+    '/play/art/shinier',
+    '/play/art/shinierier',
+    '/play/art/sprout',
+    '/play/art/stix',
+    '/play/art/theme',
+    '/play/art/weave',
+    // Uncurated flash demos (only xspf is indexed)
+    '/play/flash/flashpress',
+    '/play/flash/gallery',
+    '/play/flash/giga-player',
+    '/play/flash/interactive-ui',
+    '/play/flash/viewr',
+  ],
 }

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -2,34 +2,25 @@
 module.exports = {
   siteUrl: process.env.SITE_URL || 'https://www.lacymorrow.com',
   generateRobotsTxt: true,
+  // next-sitemap's matcher supports `*` wildcards and `!`-prefix negation only
+  // (not minimatch / extglobs). Use wildcards plus explicit negations so the
+  // curated demos listed in each section's _meta.json stay indexed and any
+  // newly-added experiments get excluded automatically.
   exclude: [
     '/sink',
     '/lacy',
     '/404',
     // Archive pages: kept for permalinks but not part of the active site
+    '/about/archive',
     '/about/archive/*',
-    // Uncurated art experiments (only the ones in play/art/_meta.json are indexed)
-    '/play/art/blank',
-    '/play/art/continual',
-    '/play/art/converge',
-    '/play/art/lines',
-    '/play/art/multi',
-    '/play/art/offset',
-    '/play/art/orbit',
-    '/play/art/scribble',
-    '/play/art/scribe',
-    '/play/art/shine',
-    '/play/art/shinier',
-    '/play/art/shinierier',
-    '/play/art/sprout',
-    '/play/art/stix',
-    '/play/art/theme',
-    '/play/art/weave',
-    // Uncurated flash demos (only xspf is indexed)
-    '/play/flash/flashpress',
-    '/play/flash/gallery',
-    '/play/flash/giga-player',
-    '/play/flash/interactive-ui',
-    '/play/flash/viewr',
+    // Uncurated art experiments — curated entries in play/art/_meta.json stay indexed
+    '/play/art/*',
+    '!/play/art/isometrics',
+    '!/play/art/tree',
+    '!/play/art/rtext',
+    '!/play/art/expand',
+    // Uncurated flash demos — only xspf is curated
+    '/play/flash/*',
+    '!/play/flash/xspf',
   ],
 }

--- a/src/pages/about/archive/_meta.json
+++ b/src/pages/about/archive/_meta.json
@@ -1,0 +1,14 @@
+{
+  "hackpack": {
+    "title": "Hackpack",
+    "display": "hidden"
+  },
+  "hypem": {
+    "title": "Hype Machine",
+    "display": "hidden"
+  },
+  "zsa": {
+    "title": "ZSA",
+    "display": "hidden"
+  }
+}


### PR DESCRIPTION
## Summary

Resolves orphan-page warnings flagged in the AHREFS triage ([LAC-1247](/LAC/issues/LAC-1247), source [LAC-963](/LAC/issues/LAC-963)).

Full audit found 24 orphan pages:
- **16 art experiments** under `src/pages/play/art/` not listed in the directory's `_meta.json`
- **5 legacy flash demos** under `src/pages/play/flash/` not listed in the directory's `_meta.json`
- **3 archive pages** under `src/pages/about/archive/` (no `_meta.json` existed)
- `privacy.mdx` — already present in root `_meta.json` (hidden); no action needed

## Changes

- Added `src/pages/about/archive/_meta.json` with `display: "hidden"` entries for `hackpack`, `hypem`, `zsa` so Nextra registers them.
- Updated `next-sitemap.config.js` to exclude the uncurated art experiments, legacy flash demos, and the entire `/about/archive/*` subtree from sitemap generation.

The curated demos that are intentionally exposed (`isometrics`, `tree`, `rtext`, `expand`, `xspf`) remain in their `_meta.json` and in the sitemap.

## Test plan

- [ ] Run `pnpm build` and inspect generated `public/sitemap-0.xml` to confirm the listed orphan URLs are absent and the curated demos are present.
- [ ] Confirm `/about/archive/hackpack`, `/about/archive/hypem`, `/about/archive/zsa` still render (Nextra now has metadata).
- [ ] Re-run AHREFS site audit after deploy to confirm orphan count drops.