### PR TITLE
feat(play): add external website links + LAC-1896 README fixes

### DIFF
--- a/src/pages/play/juno.mdx
+++ b/src/pages/play/juno.mdx
@@ -2,7 +2,7 @@
 
 <Lead>AI that controls your Mac. Describe a task, watch it happen. Native macOS desktop app powered by Anthropic Computer Use and Claude.</Lead>
 
-<Lead>**[github.com/lacymorrow/juno ↗](https://github.com/lacymorrow/juno)**</Lead>
+<Lead>**[junebug.ai ↗](https://junebug.ai)** · **[github.com/lacymorrow/juno ↗](https://github.com/lacymorrow/juno)**</Lead>
 
 ## About
 

--- a/src/pages/play/lacy.mdx
+++ b/src/pages/play/lacy.mdx
@@ -2,7 +2,7 @@
 
 <Lead>Talk to your shell — commands run, questions go to AI. No prefixes, no friction. A zsh/bash plugin that routes intent to the right place.</Lead>
 
-<Lead>**[github.com/lacymorrow/lacy ↗](https://github.com/lacymorrow/lacy)**</Lead>
+<Lead>**[lacy.sh ↗](https://lacy.sh)** · **[github.com/lacymorrow/lacy ↗](https://github.com/lacymorrow/lacy)**</Lead>
 
 ## About
 


### PR DESCRIPTION
## Summary
- Adds external website links (`junebug.ai`, `lacy.sh`) to the juno and lacy project pages, per the LAC-1896 brief ("Make sure they have proper links to the external websites if they have them").
- The README image-path fixes for the rendered Readme component are made in each project's own repo (relative paths → `raw.githubusercontent.com` URLs). Companion PRs:
  - lacymorrow/juno#462
  - lacymorrow/hitchhikersgalaxy.guide#3
  - lacymorrow/paperclip-hub#42
  - lacymorrow/shipx#22
  - lacymorrow/lacy#64

Paperclip: LAC-1896.

## Test plan
- [ ] /play/juno shows the junebug.ai link
- [ ] /play/lacy shows the lacy.sh link
- [ ] After companion PRs merge, the embedded READMEs render screenshots/gifs on the project pages.