### PR TITLE
fix(portfolio): restore external URLs for homepage project cards [LAC-1842]

### DIFF
--- a/src/components/pages/home/currently_working.tsx
+++ b/src/components/pages/home/currently_working.tsx
@@ -8,12 +8,12 @@ const CurrentlyWorking = () => {
     {
       title: "Lacy Shell",
       description: "Talk to your terminal. Natural language routes to AI agents automatically.",
-      href: "/play/lacy",
+      href: "https://lacy.sh",
     },
     {
       title: "Juno",
       description: "Anthropic Computer Use for your desktop. AI that sees and clicks.",
-      href: "/play/juno",
+      href: "https://junebug.ai",
     },
     {
       title: "Shipkit",
@@ -38,12 +38,12 @@ const CurrentlyWorking = () => {
     {
       title: "shipx",
       description: "Interactive release CLI — bump, tag, publish, and ship from one command.",
-      href: "/play/shipx",
+      href: "https://github.com/lacymorrow/shipx",
     },
     {
       title: "Paperclip Hub",
       description: "Plugin hub & marketplace for Paperclip AI agents.",
-      href: "/play/paperclip-hub",
+      href: "https://cliphub.fyi",
     },
   ];
 

--- a/src/components/pages/home/past_projects.tsx
+++ b/src/components/pages/home/past_projects.tsx
@@ -18,12 +18,12 @@ const PastProjects = () => {
     {
       title: "CrossOver",
       description: "Gaming overlay for any screen. Windows, Mac, and Linux.",
-      href: "/play/crossover",
+      href: "https://gh.lacymorrow.com/crossover",
     },
     {
       title: "Hitchhiker's Guide to the Galaxy",
       description: "My favorite book, now an AI. Ask it anything. Probably inaccurately.",
-      href: "/play/hitchhikersgalaxy",
+      href: "https://hitchhikersgalaxy.guide",
     },
     {
       title: "Cloud0 AI Chat",


### PR DESCRIPTION
## Summary
- Restore external project URLs on homepage cards that were incorrectly changed to internal `/play/` pages
- **Currently Working On**: Lacy Shell → lacy.sh, Juno → junebug.ai, shipx → GitHub repo, Paperclip Hub → cliphub.fyi
- **Past Projects**: CrossOver → gh.lacymorrow.com/crossover, Hitchhiker's Guide → hitchhikersgalaxy.guide

## Context
The previous PR (#29) cherry-picked a commit that changed homepage card links from external project URLs to internal portfolio detail pages. The homepage should link to the actual project, not the portfolio writeup.

The sidebar issue (shipx/lacy/juno not appearing in `/play` sidebar) was a deployment timing issue — the MDX files and `_meta.json` entries are correct and all pages build successfully.

## Test plan
- [ ] Verify homepage "Currently Working On" cards link to external project URLs
- [ ] Verify homepage "Past Projects" cards link to external project URLs
- [ ] Verify `/play` sidebar shows all entries including juno, lacy, shipx, paperclip-hub
- [ ] Build passes (verified locally)