### PR TITLE
feat(play): add npm and GitHub links to all package pages [LAC-1897]

### DIFF
--- a/src/pages/play/js/album-art.mdx
+++ b/src/pages/play/js/album-art.mdx
@@ -1,5 +1,7 @@
 # `album-art`
 
+**[npm ↗](https://www.npmjs.com/package/album-art)** | **[GitHub ↗](https://github.com/lacymorrow/album-art)**
+
 ## Installation
 
 ```sh npm2yarn

--- a/src/pages/play/js/eslint-standard.mdx
+++ b/src/pages/play/js/eslint-standard.mdx
@@ -1,5 +1,7 @@
 # `eslint-standard`
 
+**[npm ↗](https://www.npmjs.com/package/eslint-standard)** | **[GitHub ↗](https://github.com/lacymorrow/eslint-standard)**
+
 ## Installation
 
 ```sh npm2yarn

--- a/src/pages/play/js/hyper2-border.mdx
+++ b/src/pages/play/js/hyper2-border.mdx
@@ -1,5 +1,7 @@
 # `hyper2-border`
 
+**[npm ↗](https://www.npmjs.com/package/hyper2-border)** | **[GitHub ↗](https://github.com/lacymorrow/hyper2-border)**
+
 ## Installation
 
 ```sh npm2yarn

--- a/src/pages/play/js/movie-art.mdx
+++ b/src/pages/play/js/movie-art.mdx
@@ -1,5 +1,7 @@
 # `movie-art`
 
+**[npm ↗](https://www.npmjs.com/package/movie-art)** | **[GitHub ↗](https://github.com/lacymorrow/movie-art)**
+
 ## Installation
 
 ```sh npm2yarn

--- a/src/pages/play/js/movie-info.mdx
+++ b/src/pages/play/js/movie-info.mdx
@@ -1,5 +1,7 @@
 # `movie-info`
 
+**[npm ↗](https://www.npmjs.com/package/movie-info)** | **[GitHub ↗](https://github.com/lacymorrow/movie-info)**
+
 ## Installation
 
 ```sh npm2yarn

--- a/src/pages/play/js/movie-trailer.mdx
+++ b/src/pages/play/js/movie-trailer.mdx
@@ -1,5 +1,7 @@
 # `movie-trailer`
 
+**[npm ↗](https://www.npmjs.com/package/movie-trailer)** | **[GitHub ↗](https://github.com/lacymorrow/movie-trailer)**
+
 ## Installation
 
 ```sh npm2yarn

--- a/src/pages/play/js/xplayjs.mdx
+++ b/src/pages/play/js/xplayjs.mdx
@@ -1,5 +1,7 @@
 # `xplay.js`
 
+**[GitHub ↗](https://github.com/lacymorrow/xplay-js)**
+
 ## Readme
 
 <Readme username='lacymorrow' repo='xplay-js' />

--- a/src/pages/play/js/xspf-playlist.mdx
+++ b/src/pages/play/js/xspf-playlist.mdx
@@ -1,5 +1,7 @@
 # `xspf-playlist`
 
+**[npm ↗](https://www.npmjs.com/package/xspf-playlist)** | **[GitHub ↗](https://github.com/lacymorrow/xspf-playlist)**
+
 ## Installation
 
 ```sh npm2yarn

--- a/src/pages/play/react/react-github-readme-md.mdx
+++ b/src/pages/play/react/react-github-readme-md.mdx
@@ -2,7 +2,7 @@
 
 <Lead>Fetch and render the README.md file from a GitHub repository.</Lead>
 
-<Lead>**[Demo ↗](https://6528a9ef83709c394594fc93-hscwxpgqog.chromatic.com)**</Lead>
+<Lead>**[Demo ↗](https://6528a9ef83709c394594fc93-hscwxpgqog.chromatic.com)** | **[npm ↗](https://www.npmjs.com/package/react-github-readme-md)** | **[GitHub ↗](https://github.com/lacymorrow/react-github-readme-md)**</Lead>
 
 > This component was created for use on this website.
 

--- a/src/pages/play/react/react-is-online-context.mdx
+++ b/src/pages/play/react/react-is-online-context.mdx
@@ -2,7 +2,7 @@
 
 <Lead>React context and hook to **determine whether a browser is online or not**.</Lead>
 
-<Lead>**[Demo ↗](https://656fd301733d4955d5e63a3a-vlnhooexnk.chromatic.com/)**</Lead>
+<Lead>**[Demo ↗](https://656fd301733d4955d5e63a3a-vlnhooexnk.chromatic.com/)** | **[npm ↗](https://www.npmjs.com/package/react-is-online-context)** | **[GitHub ↗](https://github.com/lacymorrow/react-is-online-context)**</Lead>
 
 Works with Electron.
 

--- a/src/pages/play/react/react-ruffle.mdx
+++ b/src/pages/play/react/react-ruffle.mdx
@@ -2,7 +2,7 @@
 
 <Lead>**Flash Player** component for React</Lead>
 
-<Lead>**[Demo ↗](https://65328f2ac70fb72ddb74ff4b-dkqemsvtwg.chromatic.com)**</Lead>
+<Lead>**[Demo ↗](https://65328f2ac70fb72ddb74ff4b-dkqemsvtwg.chromatic.com)** | **[npm ↗](https://www.npmjs.com/package/react-ruffle)** | **[GitHub ↗](https://github.com/lacymorrow/react-ruffle)**</Lead>
 
 A React component for rendering Flash & ActionScript content using the Rust-based Ruffle emulator.
 


### PR DESCRIPTION
## Summary
- Added **npm** and **GitHub** links to all 8 JavaScript library pages and all 3 React library pages
- JS pages (`album-art`, `movie-art`, `movie-info`, `movie-trailer`, `hyper2-border`, `eslint-standard`, `xspf-playlist`) get npm + GitHub links below the title
- `xplay.js` gets a GitHub link only (not published to npm)
- React pages (`react-github-readme-md`, `react-is-online-context`, `react-ruffle`) get npm + GitHub links alongside existing Demo links

## Test plan
- [ ] Verify links render correctly on each package page
- [ ] Confirm npm URLs resolve to the correct packages
- [ ] Confirm GitHub URLs resolve to the correct repos