### PR TITLE
fix(images): address PR review feedback on check-images script [LAC-1889]

### DIFF
--- a/scripts/check-images.mjs
+++ b/scripts/check-images.mjs
@@ -8,9 +8,11 @@
  */
 
 import { readFileSync, existsSync, readdirSync, statSync } from "fs";
-import { resolve, join } from "path";
+import { resolve, join, dirname } from "path";
+import { fileURLToPath } from "url";
 
-const ROOT = resolve(import.meta.dirname, "..");
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
 const PUBLIC = join(ROOT, "public");
 
 const mdxFiles = [];
@@ -26,7 +28,7 @@ function walk(dir) {
 walk(join(ROOT, "src", "pages"));
 
 const IMG_RE = /!\[[^\]]*\]\(([^)\s]+)/g;
-const SRC_RE = /(?:src|srcSet)\s*[=:]\s*["']([^"']+\.(jpe?g|png|webp|gif|svg))/gi;
+const SRC_RE = /(?:src|srcSet)\s*[=:]\s*["']([^\s"']+\.(jpe?g|png|webp|gif|svg))(?=[\s"'])/gi;
 
 let errors = 0;
 


### PR DESCRIPTION
## Summary

Addresses Gemini code review feedback from [PR #30](https://github.com/lacymorrow/lacymorrow/pull/30):

- **Node.js compat**: Replaced `import.meta.dirname` (Node 20.11+) with `fileURLToPath(import.meta.url)` for broader compatibility
- **SRC_RE regex**: Changed `[^"']+` to `[^\s"']+` so the regex stops at whitespace, preventing false positives on multi-URL `srcSet` attributes like `srcSet="/img.png 1x, /img2.png 2x"`

## Test plan

- [ ] Run `node scripts/check-images.mjs` — should exit 0 and scan 101 MDX files
- [ ] Run `pnpm build` — should succeed