### PR TITLE
feat: version timeline page and v2/v3 asset fix [LAC-2713]

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,26 @@ const nextConfig = {
   },
   redirects: async () => [
     {
+      source: "/v2",
+      destination: "/v2/index.html",
+      permanent: false,
+    },
+    {
+      source: "/v2/",
+      destination: "/v2/index.html",
+      permanent: false,
+    },
+    {
+      source: "/v3",
+      destination: "/v3/index.html",
+      permanent: false,
+    },
+    {
+      source: "/v3/",
+      destination: "/v3/index.html",
+      permanent: false,
+    },
+    {
       source: "/about/contact",
       destination: "/contact",
       permanent: true,

--- a/public/v2/index.html
+++ b/public/v2/index.html
@@ -9,6 +9,7 @@
 <!--<![endif]-->
 
 <head>
+    <base href="/v2/">
     <meta name="description" content="Lacy Morrow, A freelance web developer. I specialize in front and back-end web development, application design, and hardware maintenance. Welcome to my web playground.">
     <meta name="keywords" content="Web Development,Design,Application Development,Mobile,C C++, PHP,HTML,CSS,XSPF,JavaScript,Development">
     <meta name="author" content="Lacy Morrow">

--- a/public/v3/index.html
+++ b/public/v3/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/v3/" />
     <title>Lacy Morrow</title>
     <link rel="stylesheet" href="css/foundation.css" />
     <link rel="stylesheet" href="css/main.css" />

--- a/src/components/pages/about/versions-timeline.tsx
+++ b/src/components/pages/about/versions-timeline.tsx
@@ -1,5 +1,6 @@
 import { versions } from "@/data/versions";
 import { cn } from "@/lib/utils";
+import Link from "next/link";
 
 export const VersionsTimeline = () => {
 	return (
@@ -69,20 +70,25 @@ export const VersionsTimeline = () => {
 								))}
 							</div>
 
-							<a
-								href={v.url}
-								target={v.isCurrent ? undefined : "_blank"}
-								rel={v.isCurrent ? undefined : "noopener noreferrer"}
-								className={cn(
-									"inline-flex items-center gap-1 text-sm font-medium transition-colors",
-									v.isCurrent
-										? "text-cyan-300 hover:text-cyan-200"
-										: "text-neutral-300 hover:text-neutral-100",
-								)}
-							>
-								{v.isCurrent ? "You are here" : "Visit this version"}
-								<span aria-hidden="true">→</span>
-							</a>
+							{v.isCurrent ? (
+								<Link
+									href={v.url}
+									className="inline-flex items-center gap-1 text-sm font-medium text-cyan-300 transition-colors hover:text-cyan-200"
+								>
+									You are here
+									<span aria-hidden="true">→</span>
+								</Link>
+							) : (
+								<a
+									href={v.url}
+									target="_blank"
+									rel="noopener noreferrer"
+									className="inline-flex items-center gap-1 text-sm font-medium text-neutral-300 transition-colors hover:text-neutral-100"
+								>
+									Visit this version
+									<span aria-hidden="true">→</span>
+								</a>
+							)}
 						</article>
 					</li>
 				))}

--- a/src/components/pages/about/versions-timeline.tsx
+++ b/src/components/pages/about/versions-timeline.tsx
@@ -1,0 +1,92 @@
+import { versions } from "@/data/versions";
+import { cn } from "@/lib/utils";
+
+export const VersionsTimeline = () => {
+	return (
+		<div className="relative mx-auto max-w-3xl px-4 py-8">
+			<div
+				aria-hidden="true"
+				className="absolute bottom-4 left-6 top-4 w-px bg-gradient-to-b from-transparent via-neutral-700 to-transparent md:left-8"
+			/>
+			<ol className="space-y-10">
+				{versions.map((v) => (
+					<li key={v.version} className="relative pl-14 md:pl-20">
+						<span
+							aria-hidden="true"
+							className={cn(
+								"absolute left-3 top-6 flex h-6 w-6 items-center justify-center rounded-full border md:left-5",
+								v.isCurrent
+									? "border-cyan-400/70 bg-cyan-400/20 shadow-[0_0_16px_2px_rgba(34,211,238,0.4)]"
+									: "border-neutral-600 bg-neutral-900",
+							)}
+						>
+							<span
+								className={cn(
+									"h-2 w-2 rounded-full",
+									v.isCurrent ? "bg-cyan-300" : "bg-neutral-500",
+								)}
+							/>
+						</span>
+
+						<article
+							className={cn(
+								"rounded-xl border p-5 transition-colors md:p-6",
+								v.isCurrent
+									? "border-cyan-400/30 bg-neutral-950/70"
+									: "border-neutral-800 bg-neutral-950/40 hover:border-neutral-700",
+							)}
+						>
+							<header className="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+								<span
+									className={cn(
+										"font-mono text-xs uppercase tracking-widest",
+										v.isCurrent ? "text-cyan-300" : "text-neutral-500",
+									)}
+								>
+									{v.version}
+									{v.isCurrent && " · current"}
+								</span>
+								<h3 className="text-lg font-semibold text-neutral-100 md:text-xl">
+									{v.name}
+								</h3>
+								<span className="ml-auto text-xs text-neutral-500 md:text-sm">
+									{v.dateRange}
+								</span>
+							</header>
+
+							<p className="mb-4 text-sm leading-relaxed text-neutral-400 md:text-base">
+								{v.description}
+							</p>
+
+							<div className="mb-4 flex flex-wrap gap-1.5">
+								{v.techStack.map((tech) => (
+									<span
+										key={tech}
+										className="rounded-full border border-neutral-800 bg-neutral-900/60 px-2.5 py-0.5 text-xs text-neutral-400"
+									>
+										{tech}
+									</span>
+								))}
+							</div>
+
+							<a
+								href={v.url}
+								target={v.isCurrent ? undefined : "_blank"}
+								rel={v.isCurrent ? undefined : "noopener noreferrer"}
+								className={cn(
+									"inline-flex items-center gap-1 text-sm font-medium transition-colors",
+									v.isCurrent
+										? "text-cyan-300 hover:text-cyan-200"
+										: "text-neutral-300 hover:text-neutral-100",
+								)}
+							>
+								{v.isCurrent ? "You are here" : "Visit this version"}
+								<span aria-hidden="true">→</span>
+							</a>
+						</article>
+					</li>
+				))}
+			</ol>
+		</div>
+	);
+};

--- a/src/data/versions.ts
+++ b/src/data/versions.ts
@@ -1,0 +1,43 @@
+export interface SiteVersion {
+	version: string;
+	name: string;
+	dateRange: string;
+	techStack: string[];
+	description: string;
+	url: string;
+	screenshot?: string;
+	isCurrent: boolean;
+}
+
+export const versions: SiteVersion[] = [
+	{
+		version: "v4",
+		name: "Aurora Daybreak",
+		dateRange: "2024 – present",
+		techStack: ["Next.js 16", "Nextra v2", "React 18", "Tailwind CSS", "TypeScript", "Vercel"],
+		description:
+			"The current era. Content-first portfolio built on Next.js Pages Router and Nextra v2. MDX pages, a shared component map, and a shadcn/ui design system on top of Tailwind. Deployed on Vercel with a two-face home layout and an evolving Aurora aesthetic.",
+		url: "/",
+		isCurrent: true,
+	},
+	{
+		version: "v3",
+		name: "Off-Canvas Landing",
+		dateRange: "2014",
+		techStack: ["Foundation 5", "Grunt", "jQuery"],
+		description:
+			"A minimal single-page landing built during my time at Twilio in San Francisco. Foundation 5 with an off-canvas nav on mobile, Grunt as the build pipeline, and a compact intro pointing out to social profiles. Fast, boring, on purpose.",
+		url: "/v3/index.html",
+		isCurrent: false,
+	},
+	{
+		version: "v2",
+		name: "Foundation Portfolio",
+		dateRange: "2010 – 2013",
+		techStack: ["Foundation", "jQuery", "Orangebox", "Google Fonts"],
+		description:
+			"The original full portfolio. Built on Foundation with jQuery and Orangebox for lightbox galleries, isotope filtering across a project grid, and an inline contact form. Snapshot of my Invitae-era San Francisco work — freelance side, open source, and Flash experiments still living side by side.",
+		url: "/v2/index.html",
+		isCurrent: false,
+	},
+];

--- a/src/pages/about/_meta.json
+++ b/src/pages/about/_meta.json
@@ -21,6 +21,13 @@
       "typesetting": "article"
     }
   },
+  "versions": {
+    "title": "Time Machine",
+    "theme": {
+      "pagination": false,
+      "typesetting": "article"
+    }
+  },
   "mentions": {
     "theme": {
       "pagination": false

--- a/src/pages/about/versions.mdx
+++ b/src/pages/about/versions.mdx
@@ -1,0 +1,12 @@
+---
+title: Version Timeline
+description: Every version of lacymorrow.com since 2010. Foundation, jQuery, Grunt, Next.js — the archive is live and you can visit each one.
+---
+
+import { VersionsTimeline } from "@/components/pages/about/versions-timeline";
+
+# Version Timeline
+
+Every version of this site since 2010 is still online. Each one is a snapshot of a stack, a taste, and a chapter — Foundation and Orangebox for the freelance-and-Flash years, an off-canvas landing page from the Twilio era, and now Next.js with a two-face home. Open any of them and you get the site as it shipped that day.
+
+<VersionsTimeline />


### PR DESCRIPTION
Paperclip: [LAC-2713](/LAC/issues/LAC-2713) · parent [LAC-2696](/LAC/issues/LAC-2696)

## Summary
- Adds `/about/versions` — a Time Machine style timeline of every site version, driven by `src/data/versions.ts` and rendered by a dark, mobile-responsive component built on Tailwind primitives.
- Fixes the v2/v3 archives: relative asset URLs were resolving to root because `/v2` was 404-ing (Next.js does not auto-serve `public/v2/index.html`). Now we redirect `/v2` and `/v3` (with and without trailing slash) to their `index.html`, and add belt-and-braces `<base href="/v2/">` / `<base href="/v3/">` so relative asset URLs still resolve inside the archive even if someone deep-links to `/v2/`.
- Wired into the About navigation via `_meta.json` as "Time Machine".

## Screens
Desktop timeline: `.tmp-screenshots/versions-desktop.png`
Mobile timeline (390×844): `.tmp-screenshots/versions-mobile.png`
`/v2` loaded with full CSS/fonts/images: `.tmp-screenshots/v2-loaded.png`
`/v3` loaded with full CSS/image: `.tmp-screenshots/v3-loaded.png`

## Acceptance
- [x] `/v2` loads the old portfolio with CSS, JS, images, and fonts
- [x] `/v3` loads the old landing page with CSS, JS, and images
- [x] Timeline page at `/about/versions` with v2, v3, and current v4
- [x] Current version distinguished (cyan glow, "You are here")
- [x] Mobile responsive (single column, connector visible)
- [x] Linked from About via `_meta.json`

## Test plan
- [ ] `pnpm dev` and confirm `/about/versions`, `/v2`, `/v3` all render
- [ ] Verify tech-stack pills wrap and cards stack on <768px
- [ ] Verify no regressions elsewhere in About nav