### PR TITLE
fix: remove <base> tags from archived v2/v3 pages [LAC-2714]

### DIFF
--- a/public/v2/index.html
+++ b/public/v2/index.html
@@ -9,7 +9,6 @@
 <!--<![endif]-->
 
 <head>
-    <base href="/v2/">
     <meta name="description" content="Lacy Morrow, A freelance web developer. I specialize in front and back-end web development, application design, and hardware maintenance. Welcome to my web playground.">
     <meta name="keywords" content="Web Development,Design,Application Development,Mobile,C C++, PHP,HTML,CSS,XSPF,JavaScript,Development">
     <meta name="author" content="Lacy Morrow">

--- a/public/v3/index.html
+++ b/public/v3/index.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <base href="/v3/" />
     <title>Lacy Morrow</title>
     <link rel="stylesheet" href="css/foundation.css" />
     <link rel="stylesheet" href="css/main.css" />


### PR DESCRIPTION
## Scope reduced — most of this landed via #44 (LAC-2713)

While this PR was in review, #44 merged a near-identical implementation of the version timeline page and the v2/v3 redirect fix (duplicate ticket LAC-2713). This PR is now rebased onto main and carries only the remaining fix from review:

### Remove `<base>` tags from archived v2/v3 pages

Confirmed finding from Gemini Code Assist review: v2 is a single-page site with hash navigation (`#about`, `#contact`, `#project1`–`#project3`). With `<base href="/v2/">` present, fragment links resolve against the base URL instead of the current document (`/v2/index.html`), turning every in-page nav click into a full page navigation.

The `next.config.js` redirects to `/v2/index.html` / `/v3/index.html` (already on main via #44) make relative asset paths resolve correctly on their own, so the base tags are redundant and harmful.

**Verified locally:** `/v2` → 307 → `/v2/index.html` (200), `/v2/stylesheets/foundation.min.css` → 200, `/v3` → 307 → `/v3/index.html` (200), `/v3/css/foundation.css` → 200 — all with the base tags removed.

Closes LAC-2714.
