### PR TITLE
feat: add creed line — life is a game but not a competition [LAC-2950]

### DIFF
--- a/src/data/creed.ts
+++ b/src/data/creed.ts
@@ -14,4 +14,5 @@ export const creed: string[] = [
 	'Wear a helmet',
 	'Only break one law at a time',
 	'Good drivers occasionally miss their exit. Bad drivers never miss their exit.',
+	'Life is a game but not a competition',
 ];


### PR DESCRIPTION
Adds the creed line **"Life is a game but not a competition"** to `src/data/creed.ts`, rendered at /creed.

Per the Phase 1 authoring flow documented in the file: add a line to the array, commit, ship.

Note: the creed already contains "Life is a competition" (added earlier). This new line reads as a deliberate amendment; both are kept since the task was to *add*, not replace. Flagged on LAC-2950 in case the older line should be removed.

Closes LAC-2950.